### PR TITLE
Simple fallback for Firefox

### DIFF
--- a/appcachePercent.js
+++ b/appcachePercent.js
@@ -44,20 +44,28 @@ function progressEvent(e) {
 	var progInner = document.getElementById('prog-inner');
 	var progPercent = document.getElementById('prog-percent');
 
-	// update the percent
-	totalfiles = Number(e.total);
-	cacheProg = cacheProg + 1;
-	var progWidth = Math.round(cacheProg / totalfiles * 100);
+	if (e.lengthComputable) {
+		// update the percent
+		totalfiles = Number(e.total);
+		cacheProg = cacheProg + 1;
+		var progWidth = Math.round(cacheProg / totalfiles * 100);
 
-	// update the numerical percent
-	progPercent.innerHTML = progWidth - 1 +'%';
+		// update the numerical percent
+		progPercent.innerHTML = progWidth - 1 +'%';
 
-	// update the width of the percent bar
-	progInner.style.width = progWidth - 1 +'%';
+		// update the width of the percent bar
+		progInner.style.width = progWidth - 1 +'%';
 
-	// when it's done, run the loading done function
-	if(cacheProg >= totalfiles) {
-		loadingDone();
+		// when it's done, run the loading done function
+		if(cacheProg >= totalfiles) {
+			loadingDone();
+		}
+	} else { // looking at you, Firefox :/
+		// delete the unneeded numerical percent
+		progPercent.innerHTML = '';
+
+		// force the width of the percent bar to 100% to make the user think something is happening
+		progInner.style.width = '100%';
 	}
 }
 appCache.addEventListener('progress', progressEvent, false);

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,7 @@ http://www.html5rocks.com/en/tutorials/appcache/beginner/
 Also this:
 http://www.whatwg.org/specs/web-apps/current-work/
 
-TODO
+NOTICE
 ____________
 
-Doesn't work in Firefox. Seems like Firefox handles the Applicaiton Cache Events differently.
+This script includes a simple visual fallback for Firefox, as Firefox doesn't provide any kind of data about the total number of files into the 'progress' event.


### PR DESCRIPTION
Hi there! Thank you for this script!

I've made a simple check + visual fallback for Firefox as it gives no info about the total number of files to cache thus it's not possible to calculate the %.

Now Firefox simply shows the process bar at 100% and moving and the bottom "Loading..." message to make the user think that something is actually happening.
